### PR TITLE
Update base image to .net 8/Ubuntu Noble

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up dotnet
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "7.x"
+          dotnet-version: "8.x"
       - name: E2E tests
         run: |
           docker run --rm --detach -p 8080:8080 --name pdf2html ${{ env.TEST_TAG }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## develop
 
+* Update to .net 8.
+  * Switch base images to Ubuntu Noble (24.04 LTS).
 * Increase `font-size-multiplier` to increase text rendering fidelity and get rid of sporadic empty spaces at the end of numbers.
 * Patch and build `pdf2htmlEX` as part of this build process to use `libopenjp` instead of `libjpeg` for JPEG-2000 support.
   * All patches are in this source tree, and are applied to directly to the source of the upstream tag during build.

--- a/src/Pdf2Html/Dockerfile
+++ b/src/Pdf2Html/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build-pdf2htmlex
+FROM ubuntu:noble AS build-pdf2htmlex
 
 # Produces a patched pdf2htmlEX using libopenjp 2.7 instead of libjpeg to get JPEG2000 support.
 
@@ -26,6 +26,8 @@ RUN ./buildScripts/reportEnvs
 RUN ./buildScripts/getBuildToolsApt
 RUN ./buildScripts/getDevLibrariesApt
 RUN ./buildScripts/getPoppler
+RUN patch ./poppler/glib/poppler-enums.c.template ./patches/poppler-enums.c.template.patch
+RUN patch ./poppler/glib/poppler-private.h ./patches/poppler-private.h.patch
 RUN ./buildScripts/buildPoppler
 RUN ./buildScripts/getFontforge
 RUN ./buildScripts/buildFontforge
@@ -35,12 +37,12 @@ RUN git config user.name "CoreFiling"
 RUN git config user.email "opensource@corefiling.com"
 RUN ./buildScripts/createDebianPackage
 
-FROM mcr.microsoft.com/dotnet/sdk:7.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-noble AS build
 WORKDIR /source
 COPY ./ .
 RUN dotnet publish -c release -o /app
 
-FROM mcr.microsoft.com/dotnet/aspnet:7.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-noble
 RUN apt update && apt install -y wget
 RUN wget http://archive.ubuntu.com/ubuntu/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_2.0.3-0ubuntu1_amd64.deb
 RUN apt install -y ./libjpeg-turbo8_2.0.3-0ubuntu1_amd64.deb

--- a/src/Pdf2Html/Pdf2Html.csproj
+++ b/src/Pdf2Html/Pdf2Html.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <Version>1.0.0</Version>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Pdf2Html/pdf2htmlEX/patches/CMakeLists.patch
+++ b/src/Pdf2Html/pdf2htmlEX/patches/CMakeLists.patch
@@ -1,4 +1,15 @@
-@@ -97,6 +97,7 @@
+@@ -23,6 +23,10 @@ add_custom_target(dist
+ 
+ find_package(PkgConfig)
+ 
++include_directories(
++  /usr/include/glib-2.0
++  /usr/lib/x86_64-linux-gnu/glib-2.0/include
++)
+ 
+ # SINCE we have a very intimate relationship with a particular version of 
+ # poppler... we explicitly describe the poppler include and library 
+@@ -97,6 +101,7 @@ set(PDF2HTMLEX_LIBS ${PDF2HTMLEX_LIBS}
    ${LIB_INTL_LIBRARIES}
    ${CAIRO_LIBRARIES}
    -ljpeg

--- a/src/Pdf2Html/pdf2htmlEX/patches/poppler-enums.c.template.patch
+++ b/src/Pdf2Html/pdf2htmlEX/patches/poppler-enums.c.template.patch
@@ -1,0 +1,18 @@
+@@ -17,7 +17,7 @@ GType
+ {
+   static volatile gsize g_define_type_id__volatile = 0;
+  
+-  if (g_once_init_enter (&g_define_type_id__volatile)) {
++  if (g_once_init_enter ((gsize*) &g_define_type_id__volatile)) {
+     static const G@Type@Value values[] = {
+ /*** END value-header ***/
+ 
+@@ -31,7 +31,7 @@ GType
+     GType g_define_type_id = 
+        g_@type@_register_static (g_intern_static_string ("@EnumName@"), values);
+       
+-    g_once_init_leave (&g_define_type_id__volatile, g_define_type_id);
++    g_once_init_leave ((gsize*) &g_define_type_id__volatile, g_define_type_id);
+   }
+     
+   return g_define_type_id__volatile;

--- a/src/Pdf2Html/pdf2htmlEX/patches/poppler-private.h.patch
+++ b/src/Pdf2Html/pdf2htmlEX/patches/poppler-private.h.patch
@@ -1,0 +1,15 @@
+@@ -155,12 +155,12 @@ GType
+ type_name##_get_type (void)                                                           \
+ {                                                                                     \
+         static volatile gsize g_define_type_id__volatile = 0;                         \
+-	if (g_once_init_enter (&g_define_type_id__volatile)) {                        \
++	if (g_once_init_enter ((gsize*) &g_define_type_id__volatile)) {                        \
+ 	        GType g_define_type_id =                                              \
+ 		    g_boxed_type_register_static (g_intern_static_string (#TypeName), \
+ 		                                  (GBoxedCopyFunc) copy_func,         \
+ 						  (GBoxedFreeFunc) free_func);        \
+-		g_once_init_leave (&g_define_type_id__volatile, g_define_type_id);    \
++		g_once_init_leave ((gsize*) &g_define_type_id__volatile, g_define_type_id);    \
+ 	}                                                                             \
+ 	return g_define_type_id__volatile;                                            \
+ }

--- a/tests/E2E.Tests/E2E.Tests.csproj
+++ b/tests/E2E.Tests/E2E.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tests/E2E.Tests/Resources/CS_cheat_sheet.html
+++ b/tests/E2E.Tests/Resources/CS_cheat_sheet.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7477ce992c3a62ff37d722cb34e9b3e7e896ad4e4239830834f2bb2525231eba
-size 1318376
+oid sha256:d148ce875ec6d3d3f7cbacc314d32e8d5818fb69a0f6dc7d5ce8cbf2f9bb9ba2
+size 1216351


### PR DESCRIPTION
This allows pdf2htmlEX to target and use newer `libcairo`, which fixes graphical images with some PDF features.