### PR TITLE
Patch issue with non-breaking spaces in `pdf2HTMLEX`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   * Switch base images to Ubuntu Noble (24.04 LTS).
 * Patch and build `pdf2htmlEX` as part of this build process to use `libopenjp` instead of `libjpeg` for JPEG-2000 support.
   * All patches are in this source tree, and are applied to directly to the source of the upstream tag during build.
+* Patch issue with non-breaking spaces in `pdf2HTMLEX`.
+* Convert complex SVGs images to bitmaps.
 
 ## 0.1.0
 

--- a/src/Pdf2Html/Controllers/RootController.cs
+++ b/src/Pdf2Html/Controllers/RootController.cs
@@ -63,7 +63,7 @@ public class RootController : ControllerBase
     private async Task<(bool Success, ICollection<string> logs)> ConvertAsync(string inputFile, string outputFile)
     {
         using var p = new Process();
-        const string conversionOptions = "--embed-javascript=0 --process-outline=0 --printing=0 --bg-format=svg --decompose-ligature 1 --tounicode 1";
+        const string conversionOptions = "--embed-javascript=0 --process-outline=0 --printing=0 --bg-format=svg --svg-node-count-limit=100 --decompose-ligature 1 --tounicode 1";
         p.StartInfo = new ProcessStartInfo
         {
             FileName = "pdf2htmlEX",

--- a/src/Pdf2Html/Dockerfile
+++ b/src/Pdf2Html/Dockerfile
@@ -19,6 +19,7 @@ RUN patch ./buildScripts/versionEnvs ./patches/versionEnvs.patch
 RUN patch ./buildScripts/buildPoppler ./patches/buildPoppler.patch
 RUN patch ./buildScripts/getBuildToolsApt ./patches/getBuildToolsApt.patch
 RUN patch ./buildScripts/getDevLibrariesApt ./patches/getDevLibrariesApt.patch
+RUN patch ./pdf2htmlEX/src/util/unicode.h ./patches/unicode.h.patch
 RUN patch ./pdf2htmlEX/CMakeLists.txt ./patches/CMakeLists.patch
 
 RUN ./buildScripts/versionEnvs

--- a/src/Pdf2Html/pdf2htmlEX/patches/unicode.h.patch
+++ b/src/Pdf2Html/pdf2htmlEX/patches/unicode.h.patch
@@ -1,0 +1,19 @@
+@@ -39,9 +39,6 @@ namespace pdf2htmlEX {
+  * moz:
+  * p2h:         [------------------]            [-]           [-]          [-----------------]
+  *
+- * Note: 0xA0 (no-break space) affects word-spacing; and if "white-space:pre" is specified,
+- * \n and \r can break line, \t can shift text, so they are considered illegal.
+- *
+  * Resources (retrieved at 2015-03-16)
+  * * webkit
+  *   * Avoid querying the font cache for the zero-width space glyph ( https://bugs.webkit.org/show_bug.cgi?id=90673 )
+@@ -58,7 +55,7 @@ namespace pdf2htmlEX {
+  */
+ inline bool is_illegal_unicode(Unicode c)
+ {
+-    return (c < 0x20) || (c >= 0x7F && c <= 0xA0) || (c == 0xAD)
++    return (c < 0x20) || (c >= 0x7F && c < 0xA0) || (c == 0xAD)
+             || (c >= 0x300 && c <= 0x36f) // DCRH Combining diacriticals
+             || (c >= 0x1ab0 && c <= 0x1aff) // DCRH Combining diacriticals
+             || (c >= 0x1dc0 && c <= 0x1dff) // DCRH Combining diacriticals

--- a/tests/E2E.Tests/Resources/CS_cheat_sheet.html
+++ b/tests/E2E.Tests/Resources/CS_cheat_sheet.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8937481da9ecc248172cd308abec6283e0b2820ea24bf159b602c9d99cdcf9e2
-size 1203138
+oid sha256:ff65d9e1cc4864dc0db647594c33c01333faa20e0e104379b42ae2b8e9694c0a
+size 1086803


### PR DESCRIPTION
Add command line argument to convert complex SVGs images to bitmaps.