### PR TITLE
Allow the options provided to pdf2htmlEX to be configured at deployment time

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           dotnet-version: "8.x"
       - name: Unit tests
-        run: dotnet test --filter "FullyQualifiedName=Unit.Tests"
+        run: dotnet test tests/Unit.Tests/Unit.Tests.csproj
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -41,7 +41,7 @@ jobs:
       - name: E2E tests
         run: |
           docker run --rm --detach -p 8080:8080 --name pdf2html ${{ env.TEST_TAG }}
-          dotnet test --filter "FullyQualifiedName=E2E.Tests"
+          dotnet test tests/E2E.Tests/E2E.Tests.csproj
           docker stop pdf2html
       - if: github.ref_name == 'main' || github.ref_type == 'tag'
         name: Login to Docker Hub

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           lfs: true
+      - name: Set up dotnet
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "8.x"
+      - name: Unit tests
+        run: dotnet test --filter "FullyQualifiedName=Unit.Tests"
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx
@@ -32,10 +38,6 @@ jobs:
           context: ./src/Pdf2Html
           load: true
           tags: ${{ env.TEST_TAG }}
-      - name: Set up dotnet
-        uses: actions/setup-dotnet@v3
-        with:
-          dotnet-version: "8.x"
       - name: E2E tests
         run: |
           docker run --rm --detach -p 8080:8080 --name pdf2html ${{ env.TEST_TAG }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## develop
+## 0.2.0
 
 * Update to .net 8.
   * Switch base images to Ubuntu Noble (24.04 LTS).
+* Add optional overrides for command-line arguments passed to `pdf2htmlEX`.
 * Patch and build `pdf2htmlEX` as part of this build process to use `libopenjp` instead of `libjpeg` for JPEG-2000 support.
   * All patches are in this source tree, and are applied to directly to the source of the upstream tag during build.
 * Patch issue with non-breaking spaces in `pdf2HTMLEX`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 This project is a lightweight HTTP(S) interface to the [pdf2htmlex library](https://pdf2htmlex.github.io/pdf2htmlEX/).
 
+## Running via Docker
+
+```bash
+docker run -p 8080 corefiling/pdf2html:$version
+```
+
+### Overriding `pdf2htmlEX` options
+
+The command line arguments passed into `pdf2htmlEX` can be overridden by passing in environment variables prefixed by `ConversionOptions__`, e.g:
+
+```bash
+docker run -p 8080 -e ConversionOptions__BgFormat=png -e ConversionOptions__OptimizeText=true corefiling/pdf2html$version
+```
+
+The names of these setting keys are converted to lower-kebab-case arguments, and the values are converted to strings as needed - in the above example, the arguments are converted to `--bg-format=png --optimize-text=0`.
+
+The full list of arguments can be found by running `pdf2htmlEX`:
+
+```bash
+docker run corefiling/pdf2html pdf2htmlEX:$version --help
+```
+
 ## Licensing
 
 Since pdf2htmlex is licensed under the GPL, this project is too (see the LICENSE.TXT file).

--- a/pdf2html.sln
+++ b/pdf2html.sln
@@ -11,6 +11,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{C361585C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "E2E.Tests", "tests\E2E.Tests\E2E.Tests.csproj", "{9CAB9112-6B91-4615-A34A-B3C66FD3FAE1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Unit.Tests", "tests\Unit.Tests\Unit.Tests.csproj", "{1174DAD4-FE63-4CF6-9F23-3B9FB6BA409A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,9 +30,14 @@ Global
 		{9CAB9112-6B91-4615-A34A-B3C66FD3FAE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9CAB9112-6B91-4615-A34A-B3C66FD3FAE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9CAB9112-6B91-4615-A34A-B3C66FD3FAE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1174DAD4-FE63-4CF6-9F23-3B9FB6BA409A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1174DAD4-FE63-4CF6-9F23-3B9FB6BA409A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1174DAD4-FE63-4CF6-9F23-3B9FB6BA409A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1174DAD4-FE63-4CF6-9F23-3B9FB6BA409A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{D3B9B4F8-F097-4F12-AB86-72CAE0B4577C} = {ABE1E425-AA84-46A5-98EA-9B6D622EF8A5}
 		{9CAB9112-6B91-4615-A34A-B3C66FD3FAE1} = {C361585C-8D3B-4CA0-A0BF-DB74DDB00EBE}
+		{1174DAD4-FE63-4CF6-9F23-3B9FB6BA409A} = {C361585C-8D3B-4CA0-A0BF-DB74DDB00EBE}
 	EndGlobalSection
 EndGlobal

--- a/pdf2html.sln.DotSettings.user
+++ b/pdf2html.sln.DotSettings.user
@@ -1,6 +1,0 @@
-﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:String x:Key="/Default/Environment/UnitTesting/UnitTestSessionStore/Sessions/=604dc4c7_002D2a73_002D4e8b_002Daa5f_002D1f59b8b03adf/@EntryIndexedValue">&lt;SessionState ContinuousTestingMode="0" IsActive="True" Name="Test1" xmlns="urn:schemas-jetbrains-com:jetbrains-ut-session"&gt;&#xD;
-  &lt;TestAncestor&gt;&#xD;
-    &lt;TestId&gt;NUnit3x::9CAB9112-6B91-4615-A34A-B3C66FD3FAE1::net7.0::E2E.Tests.ConvertPdfTest&lt;/TestId&gt;&#xD;
-  &lt;/TestAncestor&gt;&#xD;
-&lt;/SessionState&gt;</s:String></wpf:ResourceDictionary>

--- a/pdf2html.slnx
+++ b/pdf2html.slnx
@@ -1,0 +1,5 @@
+<Solution>
+    <Project Path="src/Pdf2Html/Pdf2Html.csproj" Type="Classic C#" />
+    <Project Path="tests/E2E.Tests/E2E.Tests.csproj" Type="Classic C#" />
+    <Project Path="tests/Unit.Tests/Unit.Tests.csproj" Type="Classic C#" />
+</Solution>

--- a/src/Pdf2Html/AssemblyInfo.cs
+++ b/src/Pdf2Html/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Unit.Tests")]

--- a/src/Pdf2Html/Program.cs
+++ b/src/Pdf2Html/Program.cs
@@ -1,10 +1,20 @@
+using Pdf2Html.Settings;
+
+using System.Diagnostics;
+using System.Reflection;
+
 var builder = WebApplication.CreateBuilder(args);
 builder.Logging.ClearProviders();
 builder.Logging.AddConsole();
 
 // Add services to the container.
 builder.Services.AddControllers();
+builder.Services.AddSingleton<ConversionOptions>();
 
 var app = builder.Build();
+var versionInfo = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location);
+app.Logger.LogInformation($"Starting {versionInfo.ProductName} {versionInfo.ProductVersion}");
+app.Logger.LogInformation($"Using pdf2htmlEX command line arguments: {app.Services.GetService<ConversionOptions>()!.CommandLineArguments}");
+
 app.MapControllers();
 app.Run();

--- a/src/Pdf2Html/Settings/ConversionOptions.cs
+++ b/src/Pdf2Html/Settings/ConversionOptions.cs
@@ -1,0 +1,16 @@
+using System.Text.RegularExpressions;
+
+namespace Pdf2Html.Settings;
+
+public class ConversionOptions(IConfiguration configuration)
+{
+    public string CommandLineArguments { get; } = ToCommandLineArguments(configuration.GetSection("ConversionOptions").AsEnumerable());
+
+    internal static string ToCommandLineArguments(IEnumerable<KeyValuePair<string, string?>> options) =>
+        string.Join(' ', options.Where(kvp => kvp.Value != null).Select(kvp => $"--{ToKebabCase(kvp.Key.Replace("ConversionOptions:", ""))}={ValueToString(kvp.Value!)}"));
+
+    private static string ValueToString(string value) => bool.TryParse(value, out var boolValue) ? (boolValue ? "1" : "0") : value;
+
+    private static string ToKebabCase(string value) =>
+        Regex.Replace(value, "(?<!^)([A-Z][a-z]|(?<=[a-z])[A-Z0-9])", "-$1", RegexOptions.Compiled).Trim().ToLower();
+}

--- a/src/Pdf2Html/appsettings.json
+++ b/src/Pdf2Html/appsettings.json
@@ -1,4 +1,13 @@
 {
+  "ConversionOptions": {
+    "EmbedJavascript": false,
+    "ProcessOutline": false,
+    "Printing": false,
+    "BgFormat": "svg",
+    "SvgNodeCountLimit": 100,
+    "DecomposeLigature": true,
+    "Tounicode": true
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/tests/Unit.Tests/ConversionOptionsTests.cs
+++ b/tests/Unit.Tests/ConversionOptionsTests.cs
@@ -1,8 +1,8 @@
-using Pdf2Html.Controllers;
+using Pdf2Html.Settings;
 
 namespace Unit.Tests;
 
-public class RootControllerTest
+public class ConversionOptionsTests
 {
     [Test]
     public void TestToCommandLineArguments()
@@ -14,7 +14,7 @@ public class RootControllerTest
             { "ConversionOptions:Hello", "World!" },
             { "ConversionOptions:FizzBuzz", "5" },
         };
-        var result = RootController.ToCommandLineArguments(input);
+        var result = ConversionOptions.ToCommandLineArguments(input);
         Assert.That(result, Is.EqualTo("--foo-bar=1 --baz-blort=0 --hello=World! --fizz-buzz=5"));
     }
 }

--- a/tests/Unit.Tests/RootControllerTest.cs
+++ b/tests/Unit.Tests/RootControllerTest.cs
@@ -1,0 +1,20 @@
+using Pdf2Html.Controllers;
+
+namespace Unit.Tests;
+
+public class RootControllerTest
+{
+    [Test]
+    public void TestToCommandLineArguments()
+    {
+        var input = new Dictionary<string, string?>
+        {
+            { "ConversionOptions:FooBar", "true" },
+            { "ConversionOptions:BazBlort", "FALSE" },
+            { "ConversionOptions:Hello", "World!" },
+            { "ConversionOptions:FizzBuzz", "5" },
+        };
+        var result = RootController.ToCommandLineArguments(input);
+        Assert.That(result, Is.EqualTo("--foo-bar=1 --baz-blort=0 --hello=World! --fizz-buzz=5"));
+    }
+}

--- a/tests/Unit.Tests/Unit.Tests.csproj
+++ b/tests/Unit.Tests/Unit.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/Pdf2Html/Pdf2Html.csproj" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unit.Tests/Usings.cs
+++ b/tests/Unit.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using NUnit.Framework;


### PR DESCRIPTION
Can be overridden using `ConversionOptions__*` variables, with the names being converted from PascalCase to kebab-case and prefixed with `--`, and boolean values converted to `0` and `1` as needed.