### PR TITLE
Patch memory corruption bug in fontforge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.2
 
 * Patch memory corruption bug due to PNG background images being the incorrect size.
+* Patch memory corruption bug in `fontforge` triggered by some fonts.
 
 ## 0.2.1
 

--- a/src/Pdf2Html/Dockerfile
+++ b/src/Pdf2Html/Dockerfile
@@ -33,6 +33,7 @@ RUN patch ./poppler/glib/poppler-enums.c.template ./patches/poppler-enums.c.temp
 RUN patch ./poppler/glib/poppler-private.h ./patches/poppler-private.h.patch
 RUN ./buildScripts/buildPoppler
 RUN ./buildScripts/getFontforge
+RUN patch ./fontforge/fontforge/tottfgpos.c ./patches/fontforge-tottfgpos.c.patch
 RUN ./buildScripts/buildFontforge
 RUN ./buildScripts/buildPdf2htmlEX
 RUN ./buildScripts/installPdf2htmlEX

--- a/src/Pdf2Html/pdf2htmlEX/patches/fontforge-tottfgpos.c.patch
+++ b/src/Pdf2Html/pdf2htmlEX/patches/fontforge-tottfgpos.c.patch
@@ -1,0 +1,13 @@
+@@ -2091,10 +2091,10 @@
+ }
+ 
+ static uint16 *FigureInitialClasses(FPST *fpst) {
+-    uint16 *initial = malloc((fpst->nccnt+1)*sizeof(uint16));
++    uint16 *initial = malloc((fpst->rule_cnt+1)*sizeof(uint16));
+     int i, cnt, j;
+ 
+-    initial[fpst->nccnt] = 0xffff;
++    initial[fpst->rule_cnt] = 0xffff;
+     for ( i=cnt=0; i<fpst->rule_cnt; ++i ) {
+ 	for ( j=0; j<cnt ; ++j )
+ 	    if ( initial[j] == fpst->rules[i].u.class.nclasses[0] )


### PR DESCRIPTION
This causes some PDFs with certain fonts to explode pdf2htmlEX, due to an incorrect argument given to `malloc()`.