### PR TITLE
Add `--process-annotation=1` to the default conversion options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1
+
+* Process PDF annotations (e.g. stamps) by default.
+
 ## 0.2.0
 
 * Update to .net 8.

--- a/src/Pdf2Html/appsettings.json
+++ b/src/Pdf2Html/appsettings.json
@@ -1,6 +1,7 @@
 {
   "ConversionOptions": {
     "EmbedJavascript": false,
+    "ProcessAnnotation": true,
     "ProcessOutline": false,
     "Printing": false,
     "BgFormat": "svg",


### PR DESCRIPTION
This will allow us to convert (e.g.) stamps to images rather than dropping them.