### PR TITLE
Fix issue with conversion of complex backgrounds to PNGs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.2
+
+* Patch memory corruption bug due to PNG background images being the incorrect size.
+
 ## 0.2.1
 
 * Process PDF annotations (e.g. stamps) by default.

--- a/src/Pdf2Html/Dockerfile
+++ b/src/Pdf2Html/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:noble AS build-pdf2htmlex
 
 # Produces a patched pdf2htmlEX using libopenjp 2.7 instead of libjpeg to get JPEG2000 support.
 
-ENV PDF2HTMLEX_BRANCH=cfl1
+ENV PDF2HTMLEX_BRANCH=
 ENV UNATTENDED="--assume-yes"
 ENV MAKE_PARALLEL="-j 4"
 ENV PDF2HTMLEX_PREFIX=/usr/local
@@ -19,6 +19,7 @@ RUN patch ./buildScripts/versionEnvs ./patches/versionEnvs.patch
 RUN patch ./buildScripts/buildPoppler ./patches/buildPoppler.patch
 RUN patch ./buildScripts/getBuildToolsApt ./patches/getBuildToolsApt.patch
 RUN patch ./buildScripts/getDevLibrariesApt ./patches/getDevLibrariesApt.patch
+RUN patch ./pdf2htmlEX/src/BackgroundRenderer/SplashBackgroundRenderer.cc ./patches/SplashBackgroundRenderer.cc.patch
 RUN patch ./pdf2htmlEX/src/util/unicode.cc ./patches/unicode.cc.patch
 RUN patch ./pdf2htmlEX/src/util/unicode.h ./patches/unicode.h.patch
 RUN patch ./pdf2htmlEX/CMakeLists.txt ./patches/CMakeLists.patch
@@ -49,7 +50,7 @@ RUN apt update && apt install -y wget
 RUN wget http://archive.ubuntu.com/ubuntu/pool/main/libj/libjpeg-turbo/libjpeg-turbo8_2.0.3-0ubuntu1_amd64.deb
 RUN apt install -y ./libjpeg-turbo8_2.0.3-0ubuntu1_amd64.deb
 COPY --from=build-pdf2htmlex /source/pdf2htmlEX/imageBuild/*.deb /pdf2htmlEX/
-RUN apt install -y libjpeg62 libopenjp2-7 /pdf2htmlEX/pdf2htmlEX-0.18.8.rc1-cfl1-*-x86_64.deb
+RUN apt install -y libjpeg62 libopenjp2-7 /pdf2htmlEX/pdf2htmlEX-0.18.8.rc1-cfl2-*-x86_64.deb
 
 WORKDIR /app
 COPY --from=build /app ./

--- a/src/Pdf2Html/Pdf2Html.csproj
+++ b/src/Pdf2Html/Pdf2Html.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
-    <Version>0.2.0</Version>
+    <Version>0.2.2</Version>
     <AssemblyName>Pdf2Html</AssemblyName>
     <RootNamespace>Pdf2Html</RootNamespace>
   </PropertyGroup>

--- a/src/Pdf2Html/pdf2htmlEX/patches/SplashBackgroundRenderer.cc.patch
+++ b/src/Pdf2Html/pdf2htmlEX/patches/SplashBackgroundRenderer.cc.patch
@@ -1,0 +1,20 @@
+@@ -137,7 +137,7 @@ void SplashBackgroundRenderer::embed_image(int pageno)
+ // end of hack
+ 	
+     // dump the background image only when it is not empty
+-    if((xmin <= xmax) && (ymin <= ymax))
++    if((xmin < xmax) && (ymin < ymax))
+     {
+         {
+             auto fn = html_renderer->str_fmt("%s/bg%x.%s", (param.embed_image ? param.tmp_dir : param.dest_dir).c_str(), pageno, format.c_str());
+@@ -185,8 +185,8 @@ void SplashBackgroundRenderer::embed_image(int pageno)
+ // There might be mem leak when exception is thrown !
+ void SplashBackgroundRenderer::dump_image(const char * filename, int x1, int y1, int x2, int y2)
+ {
+-    int width = x2 - x1 + 1;
+-    int height = y2 - y1 + 1;
++    int width = x2 - x1;
++    int height = y2 - y1;
+     if((width <= 0) || (height <= 0))
+         throw "Bad metric for background image";
+ 

--- a/src/Pdf2Html/pdf2htmlEX/patches/versionEnvs.patch
+++ b/src/Pdf2Html/pdf2htmlEX/patches/versionEnvs.patch
@@ -3,7 +3,7 @@
  # current working: 0.89.0
  
 -export PDF2HTMLEX_VERSION=0.18.8.rc2
-+export PDF2HTMLEX_VERSION=0.18.8.rc1
++export PDF2HTMLEX_VERSION=0.18.8.rc1-cfl2
  
  export POPPLER_VERSION=poppler-0.89.0
  #export POPPLER_VERSION=poppler-0.88.0

--- a/tests/E2E.Tests/Resources/CS_cheat_sheet.html
+++ b/tests/E2E.Tests/Resources/CS_cheat_sheet.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e020014ff0cab94ab78700278ed7b54852b944ccb366015b1a60ae944e0780d7
-size 1086801
+oid sha256:e79268fbecb7cdfe7a22064b59487cfdf3ab49e7eb616c6577b07914e86e26b3
+size 1086689


### PR DESCRIPTION
Also improve version strings - we now have a `-cfl2` suffix in `pdf2htmlEX` itself (rather than just the .deb file)